### PR TITLE
Better shebang for char-find

### DIFF
--- a/modules/char-find
+++ b/modules/char-find
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import curses   # our friendly painter
 stdscr = curses.initscr()       # give us a WindowObject to work with.


### PR DESCRIPTION
The shebang in `char-find` was using
```py
#!/usr/bin/python3
```

I changed it to
```py
#!/usr/bin/env python3
```